### PR TITLE
5: Adds round function, applies it to acres value in popups

### DIFF
--- a/scripts/functions.js
+++ b/scripts/functions.js
@@ -68,3 +68,12 @@ function clearpopups(){
 		e => e.remove()
 	);
 }
+
+
+function round(num, dp) {
+	let multiplier = 1;
+	if (dp !== undefined) {
+		multiplier = Math.pow(10, dp);
+	}
+	return (Math.round((num + Number.EPSILON) * multiplier) / multiplier);
+}

--- a/scripts/onload.js
+++ b/scripts/onload.js
@@ -76,7 +76,7 @@ function fillpopup(data){
 	html = html + "<br>"
 	html = html + "<span class='varname'>Protection Mechanism: </span> <span class='attribute'>" + data.Type + "</span>";
 	html = html + "<br>"
-	html = html + "<span class='varname'>Acres: </span> <span class='attribute'>" + data.Acres_GIS + "</span>";
+	html = html + "<span class='varname'>Acres: </span> <span class='attribute'>" + round(data.Acres_GIS, 1) + "</span>";
 	return html;
 	//this will return the string to the calling function
 }


### PR DESCRIPTION
Resolves #5 

The reasons that this is more than a one-line change are arcane.  From 30,000 feet: JavaScript's built-in rounding functions do some weird things when values are exactly half way, or have really small differences (e.g. 1.00001).  Also with negative values, but that probably isn't going to be relevant here.